### PR TITLE
add edimax dongle device IDs

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -140,6 +140,7 @@ static void rtw_dev_shutdown(struct device *dev)
 
 
 #define USB_VENDER_ID_REALTEK		0x0BDA
+#define USB_VENDER_ID_EDIMAX		0x7392  //EDX
 
 
 /* DID_USB_v916_20130116 */
@@ -234,6 +235,8 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/*=== Realtek demoboard ===*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB82C, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Default ID for USB multi-function */
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB812, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, /* Default ID for USB Single-function, WiFi only */
+	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xB822, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, //EDX
+	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xC822, 0xff, 0xff, 0xff), .driver_info = RTL8822B}, //EDX	
 #endif /* CONFIG_RTL8822B */
 
 #ifdef CONFIG_RTL8723D


### PR DESCRIPTION
Hi,

I was using the driver downloaded from edimax website for my USB dongle (8822bu), but it didn't compile anymore for linux 4.15. See the 5.2.4 branch on https://github.com/joske/rtl8822bu
I tried to fix the compile issues, and it compiled but the driver caused a kernel panic on load.

The device is an edimax AC1200.

I then found your repo and added the device IDs from the edimax sources. This works for me. 

For some reason the 5GHz band isn't working, but for the rest your driver works fine.

Relevant info:
Bus 002 Device 004: ID 7392:b822 Edimax Technology Co., Ltd 

Cheers,
Jos

